### PR TITLE
Fix: Rename namespace after move to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2017 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/factory-muffin-definition
+@see https://github.com/ergebnis/factory-muffin-definition
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,47 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.1.0...master`][1.1.0...master].
+For a full diff see [`2.0.0...master`][2.0.0...master].
+
+## [`2.0.0`][2.0.0]
+
+For a full diff see [`1.1.0...2.0.0`][1.1.0...2.0.0].
 
 ### Changed
 
 * Required `league/factory-muffin` ([#49]), by [@localheinz]
 * Added return type declarations ([#51]), by [@localheinz]
+* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#53]), by [@localheinz]
+
+  Run
+
+  ```
+  $ composer remove ergebnis/factory-muffin-definition
+  ```
+
+  and
+
+  ```
+  $ composer require ergebnis/factory-muffin-definition
+  ```
+
+  to update.
+
+  Run
+
+  ```
+  $ find . -type f -exec sed -i '.bak' 's/Ergebnis\\FactoryMuffin\\Definition/Ergebnis\\FactoryMuffin\\Definition/g' {} \;
+  ```
+
+  to replace occurrences of `Localheinz\FactoryMuffin\Definition` with `Ergebnis\FactoryMuffin\Definition`.
+
+  Run
+
+  ```
+  $ find -type f -name '*.bak' -delete
+  ```
+
+  to delete backup files created in the previous step.
 
 ## [`1.1.0`][1.1.0]
 
@@ -25,15 +60,19 @@ For a full diff see [`5d218c3...1.0.0`][5d218c3...1.0.0].
 
 * Added `Definitions` ([#1]), by [@localheinz]
 
-[1.0.0]: https://github.com/localheinz/factory-muffin-definition/tag/1.0.0
-[1.1.0]: https://github.com/localheinz/factory-muffin-definition/tag/1.1.0
+[1.0.0]: https://github.com/ergebnis/factory-muffin-definition/tag/1.0.0
+[1.1.0]: https://github.com/ergebnis/factory-muffin-definition/tag/1.1.0
+[2.0.0]: https://github.com/ergebnis/factory-muffin-definition/tag/2.0.0
 
-[5d218c3...1.0.0]: https://github.com/localheinz/factory-muffin-definition/compare/5d218c3...1.0.0
-[1.0.0...1.1.0]: https://github.com/localheinz/factory-muffin-definition/compare/1.0.0...1.1.0
-[1.1.0...master]: https://github.com/localheinz/factory-muffin-definition/compare/1.1.0...master
+[5d218c3...1.0.0]: https://github.com/ergebnis/factory-muffin-definition/compare/5d218c3...1.0.0
+[1.0.0...1.1.0]: https://github.com/ergebnis/factory-muffin-definition/compare/1.0.0...1.1.0
+[1.1.0...2.0.0]: https://github.com/ergebnis/factory-muffin-definition/compare/1.1.0...2.0.0
+[2.0.0...master]: https://github.com/ergebnis/factory-muffin-definition/compare/2.0.0...master
 
-[#1]: https://github.com/localheinz/factory-muffin-definition/pull/1
-[#49]: https://github.com/localheinz/factory-muffin-definition/pull/49
-[#51]: https://github.com/localheinz/factory-muffin-definition/pull/51
+[#1]: https://github.com/ergebnis/factory-muffin-definition/pull/1
+[#49]: https://github.com/ergebnis/factory-muffin-definition/pull/49
+[#51]: https://github.com/ergebnis/factory-muffin-definition/pull/51
+[#53]: https://github.com/ergebnis/factory-muffin-definition/pull/53
 
+[@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # factory-muffin-definition
 
-[![Continuous Integration](https://github.com/localheinz/factory-muffin-definition/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/factory-muffin-definition/actions)
-[![Code Coverage](https://codecov.io/gh/localheinz/factory-muffin-definition/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/factory-muffin-definition)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/factory-muffin-definition/v/stable)](https://packagist.org/packages/localheinz/factory-muffin-definition)
-[![Total Downloads](https://poser.pugx.org/localheinz/factory-muffin-definition/downloads)](https://packagist.org/packages/localheinz/factory-muffin-definition)
+[![Continuous Integration](https://github.com/ergebnis/factory-muffin-definition/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/factory-muffin-definition/actions)
+[![Code Coverage](https://codecov.io/gh/ergebnis/factory-muffin-definition/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/factory-muffin-definition)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/factory-muffin-definition/v/stable)](https://packagist.org/packages/ergebnis/factory-muffin-definition)
+[![Total Downloads](https://poser.pugx.org/ergebnis/factory-muffin-definition/downloads)](https://packagist.org/packages/ergebnis/factory-muffin-definition)
 
 Inspired by [`ergebnis/factory-girl-definition`](https://github.com/ergebnis/factory-girl-definition), this provides an interface for, and an easy way to find and register entity definitions for [`league/factory-muffin`](https://github.com/thephpleague/factory-muffin).
 
@@ -12,7 +12,7 @@ Inspired by [`ergebnis/factory-girl-definition`](https://github.com/ergebnis/fac
 Run
 
 ```
-$ composer require --dev localheinz/factory-muffin-definition
+$ composer require --dev ergebnis/factory-muffin-definition
 ```
 
 ## Usage
@@ -27,9 +27,9 @@ that is passed in into `accept()` to define entities:
 
 namespace Foo\Bar\Test\Fixture\Entity;
 
+use Ergebnis\FactoryMuffin\Definition\Definition;
 use Foo\Bar\Entity;
 use League\FactoryMuffin\FactoryMuffin;
-use Localheinz\FactoryMuffin\Definition\Definition;
 
 final class UserDefinition implements Definition
 {
@@ -55,9 +55,9 @@ and use `Definitions` to find definitions and register them with the factory:
 
 namespace Foo\Bar\Test\Integration;
 
+use Ergebnis\FactoryMuffin\Definition\Definitions;
 use League\FactoryMuffin\FactoryMuffin;
 use League\FactoryMuffin\Stores;
-use Localheinz\FactoryMuffin\Definition\Definitions;
 use PHPUnit\Framework;
 
 abstract class AbstractIntegrationTestCase extends Framework\TestCase

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "localheinz/factory-muffin-definition",
+  "name": "ergebnis/factory-muffin-definition",
   "type": "library",
   "description": "Provides an interface for, and an easy way to find and register entity definitions for league/factory-muffin.",
-  "homepage": "https://github.com/localheinz/factory-muffin-definition",
+  "homepage": "https://github.com/ergebnis/factory-muffin-definition",
   "license": "MIT",
   "authors": [
     {
@@ -14,6 +14,9 @@
     "php": "^7.2",
     "ergebnis/classy": "~0.5.0",
     "league/factory-muffin": "^3.0.1"
+  },
+  "replace": {
+    "localheinz/factory-muffin-definition": "*"
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.0.0",
@@ -34,16 +37,16 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\FactoryMuffin\\Definition\\": "src/"
+      "Ergebnis\\FactoryMuffin\\Definition\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\FactoryMuffin\\Definition\\Test\\": "test/"
+      "Ergebnis\\FactoryMuffin\\Definition\\Test\\": "test/"
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/factory-muffin-definition/issues",
-    "source": "https://github.com/localheinz/factory-muffin-definition"
+    "issues": "https://github.com/ergebnis/factory-muffin-definition/issues",
+    "source": "https://github.com/ergebnis/factory-muffin-definition"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1c36d7b2bc9b0519941fd8cd7065ae5",
+    "content-hash": "e96d4343532643ef50cd22790e10d774",
     "packages": [
         {
             "name": "ergebnis/classy",

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition;
+namespace Ergebnis\FactoryMuffin\Definition;
 
 use League\FactoryMuffin\FactoryMuffin;
 

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition;
+namespace Ergebnis\FactoryMuffin\Definition;
 
 use Ergebnis\Classy;
 use League\FactoryMuffin\FactoryMuffin;

--- a/src/Exception/InvalidDefinition.php
+++ b/src/Exception/InvalidDefinition.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition\Exception;
+namespace Ergebnis\FactoryMuffin\Definition\Exception;
 
 final class InvalidDefinition extends \RuntimeException
 {

--- a/src/Exception/InvalidDirectory.php
+++ b/src/Exception/InvalidDirectory.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition\Exception;
+namespace Ergebnis\FactoryMuffin\Definition\Exception;
 
 final class InvalidDirectory extends \InvalidArgumentException
 {

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition\Test\AutoReview;
+namespace Ergebnis\FactoryMuffin\Definition\Test\AutoReview;
 
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -29,8 +29,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src',
-            'Localheinz\\FactoryMuffin\\Definition\\',
-            'Localheinz\\FactoryMuffin\\Definition\\Test\\Unit\\'
+            'Ergebnis\\FactoryMuffin\\Definition\\',
+            'Ergebnis\\FactoryMuffin\\Definition\\Test\\Unit\\'
         );
     }
 }

--- a/test/Fixture/Definition/Acceptable/UserDefinition.php
+++ b/test/Fixture/Definition/Acceptable/UserDefinition.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition\Test\Fixture\Definition\Acceptable;
+namespace Ergebnis\FactoryMuffin\Definition\Test\Fixture\Definition\Acceptable;
 
+use Ergebnis\FactoryMuffin\Definition\Definition;
 use League\FactoryMuffin\FactoryMuffin;
-use Localheinz\FactoryMuffin\Definition\Definition;
 
 /**
  * Is acceptable as it implements the interface.

--- a/test/Fixture/Definition/DoesNotImplementInterface/UserDefinition.php
+++ b/test/Fixture/Definition/DoesNotImplementInterface/UserDefinition.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition\Test\Fixture\Definition\DoesNotImplementInterface;
+namespace Ergebnis\FactoryMuffin\Definition\Test\Fixture\Definition\DoesNotImplementInterface;
 
+use Ergebnis\FactoryMuffin\Definition\Test\Fixture\Entity;
 use League\FactoryMuffin\FactoryMuffin;
-use Localheinz\FactoryMuffin\Definition\Test\Fixture\Entity;
 
 /**
  * Is not acceptable as it does not implement the DefinitionInterface.

--- a/test/Fixture/Definition/IsAbstract/UserDefinition.php
+++ b/test/Fixture/Definition/IsAbstract/UserDefinition.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition\Test\Fixture\Definition\IsAbstract;
+namespace Ergebnis\FactoryMuffin\Definition\Test\Fixture\Definition\IsAbstract;
 
+use Ergebnis\FactoryMuffin\Definition\Definition;
+use Ergebnis\FactoryMuffin\Definition\Test\Fixture\Entity;
 use League\FactoryMuffin\FactoryMuffin;
-use Localheinz\FactoryMuffin\Definition\Definition;
-use Localheinz\FactoryMuffin\Definition\Test\Fixture\Entity;
 
 /**
  * Is not acceptable as it is abstract.

--- a/test/Fixture/Definition/PrivateConstructor/UserDefinition.php
+++ b/test/Fixture/Definition/PrivateConstructor/UserDefinition.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition\Test\Fixture\Definition\PrivateConstructor;
+namespace Ergebnis\FactoryMuffin\Definition\Test\Fixture\Definition\PrivateConstructor;
 
+use Ergebnis\FactoryMuffin\Definition\Definition;
+use Ergebnis\FactoryMuffin\Definition\Test\Fixture\Entity;
 use League\FactoryMuffin\FactoryMuffin;
-use Localheinz\FactoryMuffin\Definition\Definition;
-use Localheinz\FactoryMuffin\Definition\Test\Fixture\Entity;
 
 /**
  * Is not acceptable as it has a private constructor.

--- a/test/Fixture/Definition/ThrowsExceptionDuringConstruction/UserDefinition.php
+++ b/test/Fixture/Definition/ThrowsExceptionDuringConstruction/UserDefinition.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition\Test\Fixture\Definition\ThrowsExceptionDuringConstruction;
+namespace Ergebnis\FactoryMuffin\Definition\Test\Fixture\Definition\ThrowsExceptionDuringConstruction;
 
+use Ergebnis\FactoryMuffin\Definition\Definition;
+use Ergebnis\FactoryMuffin\Definition\Test\Fixture\Entity;
 use League\FactoryMuffin\FactoryMuffin;
-use Localheinz\FactoryMuffin\Definition\Definition;
-use Localheinz\FactoryMuffin\Definition\Test\Fixture\Entity;
 
 /**
  * Is not acceptable as it throws an exception during construction.

--- a/test/Fixture/Entity/User.php
+++ b/test/Fixture/Entity/User.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition\Test\Fixture\Entity;
+namespace Ergebnis\FactoryMuffin\Definition\Test\Fixture\Entity;
 
 final class User
 {

--- a/test/Unit/DefinitionsTest.php
+++ b/test/Unit/DefinitionsTest.php
@@ -8,25 +8,25 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition\Test\Unit;
+namespace Ergebnis\FactoryMuffin\Definition\Test\Unit;
 
+use Ergebnis\FactoryMuffin\Definition\Definitions;
+use Ergebnis\FactoryMuffin\Definition\Exception;
 use Ergebnis\Test\Util\Helper;
 use League\FactoryMuffin\FactoryMuffin;
-use Localheinz\FactoryMuffin\Definition\Definitions;
-use Localheinz\FactoryMuffin\Definition\Exception;
 use PHPUnit\Framework;
 use Prophecy\Argument;
 
 /**
  * @internal
  *
- * @covers \Localheinz\FactoryMuffin\Definition\Definitions
+ * @covers \Ergebnis\FactoryMuffin\Definition\Definitions
  *
- * @uses \Localheinz\FactoryMuffin\Definition\Exception\InvalidDefinition
- * @uses \Localheinz\FactoryMuffin\Definition\Exception\InvalidDirectory
+ * @uses \Ergebnis\FactoryMuffin\Definition\Exception\InvalidDefinition
+ * @uses \Ergebnis\FactoryMuffin\Definition\Exception\InvalidDirectory
  */
 final class DefinitionsTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/InvalidDefinitionTest.php
+++ b/test/Unit/Exception/InvalidDefinitionTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition\Test\Unit\Exception;
+namespace Ergebnis\FactoryMuffin\Definition\Test\Unit\Exception;
 
+use Ergebnis\FactoryMuffin\Definition\Exception;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\FactoryMuffin\Definition\Exception;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\FactoryMuffin\Definition\Exception\InvalidDefinition
+ * @covers \Ergebnis\FactoryMuffin\Definition\Exception\InvalidDefinition
  */
 final class InvalidDefinitionTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/InvalidDirectoryTest.php
+++ b/test/Unit/Exception/InvalidDirectoryTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/factory-muffin-definition
+ * @see https://github.com/ergebnis/factory-muffin-definition
  */
 
-namespace Localheinz\FactoryMuffin\Definition\Test\Unit\Exception;
+namespace Ergebnis\FactoryMuffin\Definition\Test\Unit\Exception;
 
+use Ergebnis\FactoryMuffin\Definition\Exception;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\FactoryMuffin\Definition\Exception;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\FactoryMuffin\Definition\Exception\InvalidDirectory
+ * @covers \Ergebnis\FactoryMuffin\Definition\Exception\InvalidDirectory
  */
 final class InvalidDirectoryTest extends Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] renames the vendor namespace `Localheinz` to `Ergebnis` after the move to @ergebnis