### PR TITLE
Fix: Add return type declaration in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ use Localheinz\FactoryMuffin\Definition\Definition;
 
 final class UserDefinition implements Definition
 {
-    public function accept(FactoryMuffin $factoryMuffin)
+    public function accept(FactoryMuffin $factoryMuffin): void
     {
         $factoryMuffin->define(Entity\User::class)->setDefinitions([
             // ...


### PR DESCRIPTION
This PR

* [x] adds return type declarations in `README.md`

Follows #51.