### PR TITLE
Fix: Use main as default branch name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,7 +1,7 @@
 # https://github.com/probot/settings
 
 branches:
-  - name: "master"
+  - name: "main"
 
     # https://developer.github.com/v3/repos/branches/#remove-branch-protection
     # https://developer.github.com/v3/repos/branches/#update-branch-protection
@@ -80,7 +80,7 @@ repository:
   allow_rebase_merge: false
   allow_squash_merge: false
   archived: false
-  default_branch: "master"
+  default_branch: "main"
   delete_branch_on_merge: true
   description: ":girl: Provides an interface for, and an easy way to find and register entity definitions for league/factory-muffin."
   has_downloads: true

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
   pull_request: null
   push:
     branches:
-      - "master"
+      - "main"
 
 env:
   MIN_COVERED_MSI: 93

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.0.0...master`][2.0.0...master].
+For a full diff see [`2.0.0...main`][2.0.0...main].
 
 ## [`2.0.0`][2.0.0]
 
@@ -67,7 +67,7 @@ For a full diff see [`5d218c3...1.0.0`][5d218c3...1.0.0].
 [5d218c3...1.0.0]: https://github.com/ergebnis/factory-muffin-definition/compare/5d218c3...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/factory-muffin-definition/compare/1.0.0...1.1.0
 [1.1.0...2.0.0]: https://github.com/ergebnis/factory-muffin-definition/compare/1.1.0...2.0.0
-[2.0.0...master]: https://github.com/ergebnis/factory-muffin-definition/compare/2.0.0...master
+[2.0.0...main]: https://github.com/ergebnis/factory-muffin-definition/compare/2.0.0...main
 
 [#1]: https://github.com/ergebnis/factory-muffin-definition/pull/1
 [#49]: https://github.com/ergebnis/factory-muffin-definition/pull/49

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # factory-muffin-definition
 
-[![Integrate](https://github.com/ergebnis/factory-muffin-definition/workflows/Integrate/badge.svg?branch=master)](https://github.com/ergebnis/factory-muffin-definition/actions)
-[![Prune](https://github.com/ergebnis/factory-muffin-definition/workflows/Prune/badge.svg?branch=master)](https://github.com/ergebnis/factory-muffin-definition/actions)
-[![Release](https://github.com/ergebnis/factory-muffin-definition/workflows/Release/badge.svg?branch=master)](https://github.com/ergebnis/factory-muffin-definition/actions)
-[![Renew](https://github.com/ergebnis/factory-muffin-definition/workflows/Renew/badge.svg?branch=master)](https://github.com/ergebnis/factory-muffin-definition/actions)
+[![Integrate](https://github.com/ergebnis/factory-muffin-definition/workflows/Integrate/badge.svg?branch=main)](https://github.com/ergebnis/factory-muffin-definition/actions)
+[![Prune](https://github.com/ergebnis/factory-muffin-definition/workflows/Prune/badge.svg?branch=main)](https://github.com/ergebnis/factory-muffin-definition/actions)
+[![Release](https://github.com/ergebnis/factory-muffin-definition/workflows/Release/badge.svg?branch=main)](https://github.com/ergebnis/factory-muffin-definition/actions)
+[![Renew](https://github.com/ergebnis/factory-muffin-definition/workflows/Renew/badge.svg?branch=main)](https://github.com/ergebnis/factory-muffin-definition/actions)
 
-[![Code Coverage](https://codecov.io/gh/ergebnis/factory-muffin-definition/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/factory-muffin-definition)
+[![Code Coverage](https://codecov.io/gh/ergebnis/factory-muffin-definition/branch/main/graph/badge.svg)](https://codecov.io/gh/ergebnis/factory-muffin-definition)
 [![Type Coverage](https://shepherd.dev/github/ergebnis/factory-muffin-definition/coverage.svg)](https://shepherd.dev/github/ergebnis/factory-muffin-definition)
 
 [![Latest Stable Version](https://poser.pugx.org/ergebnis/factory-muffin-definition/v/stable)](https://packagist.org/packages/ergebnis/factory-muffin-definition)
@@ -89,7 +89,7 @@ Please have a look at [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).
 
 ## Code of Conduct
 
-Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/master/CODE_OF_CONDUCT.md).
+Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
This PR

* [x] uses `main` as default branch name

✊🏿 Black lives matter.